### PR TITLE
Fix regexp to not find extensions in the middle of a module name

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,10 +44,10 @@ export default function transformCssModules({ types: t }) {
     // is css modules require hook initialized?
     let initialized = false;
 
-    let matchExtensions = /\.css/i;
+    let matchExtensions = /\.css$/i;
     function matcher(extensions = ['.css']) {
-        const extensionsPatern = extensions.join('|').replace('.', '\.');
-        return new RegExp(`(${extensionsPatern})`, 'i');
+        const extensionsPatern = extensions.join('|').replace(/\./g, '\\\.');
+        return new RegExp(`(${extensionsPatern})$`, 'i');
     }
 
     return {

--- a/test/fixtures/extensions.expected.js
+++ b/test/fixtures/extensions.expected.js
@@ -6,3 +6,5 @@ var css = {
 var scss = {
   'sassy': 'extensions__sassy___12Yag'
 };
+var foo = require('something-that-has-css-somewhere-in-the-name');
+var bar = require('something-that-has-scss-somewhere-in-the-name');

--- a/test/fixtures/extensions.js
+++ b/test/fixtures/extensions.js
@@ -1,2 +1,4 @@
 var css = require('../styles.css');
 var scss = require('../extensions.scss');
+var foo = require('something-that-has-css-somewhere-in-the-name');
+var bar = require('something-that-has-scss-somewhere-in-the-name');

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -25,7 +25,7 @@ describe('babel-plugin-css-modules-transform', () => {
     }
 
     function readExpected(path) {
-        return readFileSync(resolve(__dirname, path), 'utf8');
+        return readFileSync(resolve(__dirname, path), 'utf8').trim();
     }
 
     it('should throw if we are requiring css module to module scope', () => {


### PR DESCRIPTION
This PR fixes the Regexp used to filter modules with the supported extensions. Previously it was incorrectly finding modules that _contained_ the extension in the middle of the name. This was both because we were not searching for the last characters in the module (using `$`) and also because it was not escaping the `.` caracter properly.

Added some more cases to the tests for this fix.

Oh and by the way, thanks for creating this module! Very helpful!