### PR TITLE
Explain why we use trim when reading test file contents

### DIFF
--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -25,6 +25,11 @@ describe('babel-plugin-css-modules-transform', () => {
     }
 
     function readExpected(path) {
+        // We trim the contents of the file so that we don't have
+        // to deal with newline issues, since some text editors
+        // automatically inserts them. It's easier to do this than to
+        // configure the editors to avoid inserting newlines for these
+        // particular files.
         return readFileSync(resolve(__dirname, path), 'utf8').trim();
     }
 


### PR DESCRIPTION
Adding some explanatory comments around the `trim` in the content of the files when testing, as suggested [here](https://github.com/michalkvasnicak/babel-plugin-css-modules-transform/pull/11#discussion_r64764728)