### PR TITLE
Fix outdating extracted CSS files, while use gulp-watch/watch with en…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -134,7 +134,7 @@ export default function transformCssModules({ types: t }) {
                     }
                     if (typeof processed !== 'string') processed = css;
 
-                    if (!state.$$css.styles.has(filepath)) {
+                    if (currentConfig.devMode || !state.$$css.styles.has(filepath)) {
                         state.$$css.styles.set(filepath, processed);
                         extractCssFile(filepath, processed);
                     }


### PR DESCRIPTION
Using babel-plugin-css-modules-transform in couple with gulp + gulp-watch + livereload has the following behaviour: when I run single build task, extractCSS works perfectly. But when I start livereload server, the initial extractCSS works perfectly also, then when I update source CSS files and gulp-watch notices these changes and performs building task again, the extracted CSS files aren't updated, they just freeze in the initial state. I use devMode flag for preventing caching files by Babel (it's really useful for livereload). So this pull-request adds supporting of this flag to babel-plugin-css-modules-transform.