### PR TITLE
Add the hashPrefix option

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ npm install --save-dev babel-plugin-css-modules-transform
                 "generateScopedName": "[name]__[local]___[hash:base64:5]", // in case you don't want to use a function
                 "generateScopedName": "./path/to/module-exporting-a-function.js", // in case you want to use a function
                 "generateScopedName": "npm-module-name",
+                "hashPrefix": "string",
                 "ignore": "*css",
                 "ignore": "./path/to/module-exporting-a-function-or-regexp.js",
                 "preprocessCss": "./path/to/module-exporting-a-function.js",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/michalkvasnicak/babel-plugin-css-modules-transform#readme",
   "dependencies": {
-    "css-modules-require-hook": "^4.0.2",
+    "css-modules-require-hook": "^4.0.3",
     "mkdirp": "^0.5.1"
   },
   "devDependencies": {

--- a/src/options_resolvers/hashPrefix.js
+++ b/src/options_resolvers/hashPrefix.js
@@ -1,0 +1,15 @@
+import { isString } from '../utils';
+
+/**
+ * Resolves hashPrefix option for css-modules-require-hook
+ *
+ * @param {*} value
+ * @returns {String}
+ */
+export default function hashPrefix(value/* , currentConfig */) {
+    if (!isString(value)) {
+        throw new Error(`Configuration 'hashPrefix' is not a string`);
+    }
+
+    return value;
+}

--- a/src/options_resolvers/index.js
+++ b/src/options_resolvers/index.js
@@ -3,6 +3,7 @@ export { default as camelCase } from './camelCase';
 export { default as createImportedName } from './createImportedName';
 export { default as devMode } from './devMode';
 export { default as generateScopedName } from './generateScopedName';
+export { default as hashPrefix } from './hashPrefix';
 export { default as ignore } from './ignore';
 export { default as mode } from './mode';
 export { default as prepend } from './prepend';

--- a/src/options_resolvers/mode.js
+++ b/src/options_resolvers/mode.js
@@ -4,7 +4,7 @@ import { isString } from '../utils';
  * Resolves mode option for css-modules-require-hook
  *
  * @param {*} value
- * @returns {boolean}
+ * @returns {String}
  */
 export default function mode(value/* , currentConfig */) {
     if (!isString(value)) {

--- a/src/options_resolvers/rootDir.js
+++ b/src/options_resolvers/rootDir.js
@@ -3,10 +3,10 @@ import { statSync } from 'fs';
 import { isString } from '../utils';
 
 /**
- * Resolves mode option for css-modules-require-hook
+ * Resolves rootDir option for css-modules-require-hook
  *
  * @param {*} value
- * @returns {boolean}
+ * @returns {String}
  */
 export default function rootDir(value/* , currentConfig */) {
     if (!isString(value)) {

--- a/test/options_resolvers/hashPrefix.spec.js
+++ b/test/options_resolvers/hashPrefix.spec.js
@@ -1,0 +1,13 @@
+import { expect } from 'chai';
+
+import hashPrefix from '../../src/options_resolvers/hashPrefix';
+
+describe('options_resolvers/hashPrefix', () => {
+    it('should throw if hashPrefix value is not a string', () => {
+        expect(
+            () => hashPrefix(null)
+        ).to.throw();
+
+        expect(hashPrefix('hashPrefix')).to.be.equal('hashPrefix');
+    });
+});


### PR DESCRIPTION
Hi,

the `hashPrefix` option has just been added as of `css-modules-require-hook@4.0.3`.
See https://github.com/css-modules/css-modules-require-hook/pull/78 for details.

So even if it should be passed right away, I though it would be good to document and test it a minimum here. More unit tests needed?


