### PR TITLE
Enable loading CSS from external deps

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,7 @@ export default function transformCssModules({ types: t }) {
             // As a last resort, require the cssFile itself. This enables loading of CSS files from external deps
             try {
                 return require(cssFile);
-            } catch (e) {
+            } catch (f) {
                 return {}; // return empty object, this simulates result of ignored stylesheet file
             }
         }

--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,12 @@ export default function transformCssModules({ types: t }) {
         try {
             return require(filePathOrModuleName);
         } catch (e) {
-            return {}; // return empty object, this simulates result of ignored stylesheet file
+            // As a last resort, require the cssFile itself. This enables loading of CSS files from external deps
+            try {
+                return require(cssFile);
+            } catch (e) {
+                return {}; // return empty object, this simulates result of ignored stylesheet file
+            }
         }
     }
 


### PR DESCRIPTION
This PR enables loading of CSS files from external dependencies. In our monorepo project, we sometimes load CSS from dependencies, like so:

```js
import modularStyles from '@company/brand/styles.css';
```

Currently, without this fix this results in:

```js
var modularStyles = {};
```

Because the css file is never being required properly.