### PR TITLE
keepImport

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,24 @@ To extract all files in a single directory, give an object:
 Note that `relativeRoot` is used to resolve relative directory names, available
 as `[path]` in `filename` pattern.
 
+## Keeping import
+
+To keep import statements you should set option `keepImport` to *true*. In this way, simultaneously with the converted values, the import will be described as unassigned call expression.
+
+```js
+// before
+const styles = require('./test.css');
+```
+
+```js
+// after
+require('./test.css');
+
+const styles = {
+    'someClass': 'Test__someClass___2Frqu'
+}
+```
+
 ## Alternatives
 
 - [babel-plugin-transform-postcss](https://github.com/wbyoung/babel-plugin-transform-postcss) - which supports async plugins and does not depend on `css-modules-require-hook`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-css-modules-transform",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Transform required css modules so one can use generated class names.",
   "main": "build/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -194,13 +194,6 @@ export default function transformCssModules({ types: t }) {
                   calleeName !== 'require'
                   || !args.length
                   || !t.isStringLiteral(args[0])
-                  // Should keep expression placed in Program or block
-                  // because modular css without assignment to the variable
-                  // has makes no sense
-                  || (
-                    t.isProgram(path.parentPath)
-                    || t.isBlockStatement(path.parentPath)
-                  )
                 ) {
                     return;
                 }

--- a/test/fixtures/require.keep.expected.js
+++ b/test/fixtures/require.keep.expected.js
@@ -1,0 +1,7 @@
+'use strict';
+
+require('../styles.css');
+
+var styles = {
+  'className': 'styles__className___385m0 parent__block___33Sxl child__line___3fweh'
+};

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -292,4 +292,10 @@ describe('babel-plugin-css-modules-transform', () => {
             'styles.css'
         ]);
     });
+
+    it('should keep require', () => {
+        expect(transform('fixtures/require.js', {
+            keepImport: true
+        }).code).to.be.equal(readExpected('fixtures/require.keep.expected.js'));
+    });
 });


### PR DESCRIPTION
I worked with a situation when I need to precompile css-modules, but keeping the ability to use css-loader later.
With option `keepImport` we got the same result, but all import statements (or require expr.)  stay kept.

```js
// before
const styles = require('./test.css');
```

```js
// after
require('./test.css');

const styles = {
    'someClass': 'Test__someClass___2Frqu'
}
```

But there are some difficulties with the tests - they do not work by default. Is this normal?