### PR TITLE
Add a new option `importPathFormatter` to format the path of css files

### DIFF
--- a/src/options_resolvers/importPathFormatter.js
+++ b/src/options_resolvers/importPathFormatter.js
@@ -1,0 +1,23 @@
+import { isFunction, isModulePath, requireLocalFileOrNodeModule } from '../utils';
+
+/**
+ * Resolves importPathFormatter option
+ *
+ * @param {String|Function} value
+ * @returns {Function}
+ */
+export default function importPathFormatter(value/* , currentConfig */) {
+    if (isFunction(value)) {
+        return value;
+    } else if (isModulePath(value)) {
+        const requiredOption = requireLocalFileOrNodeModule(value);
+
+        if (!isFunction(requiredOption)) {
+            throw new Error(`Configuration file for 'importPathFormatter' is not exporting a function`);
+        }
+
+        return requiredOption;
+    }
+
+    throw new Error(`Configuration 'importPathFormatter' is not a function nor a valid module path`);
+}

--- a/src/options_resolvers/index.js
+++ b/src/options_resolvers/index.js
@@ -13,3 +13,4 @@ export { default as processorOpts } from './processorOpts';
 export { default as rootDir } from './rootDir';
 export { default as resolve } from './resolve';
 export { default as use } from './use';
+export { default as importPathFormatter } from './importPathFormatter';

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -109,12 +109,13 @@ describe('babel-plugin-css-modules-transform', () => {
     });
 
     it('should write a multiple css files using import', () => {
-        expect(transform('fixtures/import.js', {
+        expect(transform(`${__dirname}/fixtures/import.js`, {
             extractCss: {
                 dir: `${__dirname}/output/`,
-                filename: '[name].css',
-                relativeRoot: `${__dirname}`
-            }
+                filename: '[path]/[name].css',
+                relativeRoot: __dirname
+            },
+            extensions: ['.scss', '.css']
         }).code).to.be.equal(readExpected('fixtures/import.expected.js'));
 
         expect(readExpected(`${__dirname}/output/parent.css`))


### PR DESCRIPTION
In my case, I need to update of path of css files after transforming the css-modules. 
So I add a new option `importPathFormatter`.
But It seems the test cases fail in my local environment which also fails in mater branch.

Test error messages:

```
 1) should write a multiple css files using import
    2) should write a multiple css files using import preserving directory structure
    3) should write a multiple css files using require
    4) should write a single css file using import
    5) should write a single css file using require
    6) should extract styles with a single input file via gulp
    7) should extract multiple files via gulp
    8) should extract combined files via gulp
    9) should call custom preprocess

....

 1) babel-plugin-css-modules-transform should write a multiple css files using import:
     Error: ENOENT: no such file or directory, open .../babel-plugin-css-modules-transform/test/output/parent.css'

```  