### PR TITLE
Handle exceptions inside requiring module

### DIFF
--- a/src/utils/requireLocalFileOrNodeModule.js
+++ b/src/utils/requireLocalFileOrNodeModule.js
@@ -13,7 +13,11 @@ export default function requireLocalFileOrNodeModule(path) {
         // first try to require local file
         return require(localFile);
     } catch (e) {
-        // try to require node_module
-        return require(path);
+        if (e.code === 'MODULE_NOT_FOUND') {
+            // try to require node_module
+            return require(path);
+        }
+
+        throw e;
     }
 }


### PR DESCRIPTION
We getting `Cannot find module ....` even if a file exists, but some exception was thrown inside of it
This PR fixes this behavior and rethrow exception from requiring module