### PR TITLE
Support for @scoped modules

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -53,7 +53,7 @@ export default function transformCssModules({ types: t }) {
         let filePathOrModuleName = cssFile;
 
         // only resolve path to file when we have a file path
-        if (!/^\w/i.test(filePathOrModuleName)) {
+        if (!/^\w|^@/i.test(filePathOrModuleName)) {
             const from = resolveModulePath(filepath);
             filePathOrModuleName = resolve(from, filePathOrModuleName);
         }


### PR DESCRIPTION
Lib names can be in `@somescope/lib-name` format and `^\w` regex does not cover it