### PR TITLE
Removing extra path not needed in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ When using this plugin with a preprocessor, you'll need to configure it as such:
 ```js
 // ./path/to/module-exporting-a-function.js
 var sass = require('node-sass');
-var path = require('path');
 
 module.exports = function processSass(data, filename) {
     var result;


### PR DESCRIPTION
A `path` variable is defined in one of the examples and it's not used which seems a little confusing, maybe there is a reason why it's there, if not, maybe we could remove it?